### PR TITLE
fix: authority as SystemProgram

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -9,13 +9,13 @@ skip-lint = false
 fraction = "FracVQuBhSeBvbw1qNrJKkDmcdPcFYWdneoKbJa3HMrj"
 
 [programs.devnet]
-fraction = "Ck2PtB73t36kjk4mLUztwsBV9jvq7q3mGfSNmQevwFgg"
+fraction = "SW1CganGidSZjswyi7SwJuq6QN7LdkcJgSTQhrTUyUC"
 
 [registry]
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "devnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -15,7 +15,7 @@ fraction = "FracVQuBhSeBvbw1qNrJKkDmcdPcFYWdneoKbJa3HMrj"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "mainnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -15,7 +15,7 @@ fraction = "SW1CganGidSZjswyi7SwJuq6QN7LdkcJgSTQhrTUyUC"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "localnet"
+cluster = "devnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -9,13 +9,13 @@ skip-lint = false
 fraction = "FracVQuBhSeBvbw1qNrJKkDmcdPcFYWdneoKbJa3HMrj"
 
 [programs.devnet]
-fraction = "FracVQuBhSeBvbw1qNrJKkDmcdPcFYWdneoKbJa3HMrj"
+fraction = "Ck2PtB73t36kjk4mLUztwsBV9jvq7q3mGfSNmQevwFgg"
 
 [registry]
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "localnet"
+cluster = "devnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/programs/fraction/src/instructions/initialize_fraction.rs
+++ b/programs/fraction/src/instructions/initialize_fraction.rs
@@ -56,9 +56,7 @@ impl<'info> InitializeFraction<'info> {
         ];
         for i in 0..5 {
             for j in (i + 1)..5 {
-                if wallets[i] == anchor_lang::system_program::ID
-                    || wallets[j] == anchor_lang::system_program::ID
-                {
+                if wallets[i] == anchor_lang::system_program::ID || wallets[j] == anchor_lang::system_program::ID {
                     continue;
                 }
                 require!(

--- a/programs/fraction/src/instructions/initialize_fraction.rs
+++ b/programs/fraction/src/instructions/initialize_fraction.rs
@@ -76,8 +76,8 @@ impl<'info> InitializeFraction<'info> {
             participants,
             bot_wallet,
             incentive_bps: 5u8,
-            vault_bump: bumps.fraction_vault,      // 🔑 Store vault bump
-            config_bump: bumps.fraction_config,    // Store config bump
+            vault_bump: bumps.fraction_vault,
+            config_bump: bumps.fraction_config,
         });
 
         Ok(())

--- a/programs/fraction/src/instructions/initialize_fraction.rs
+++ b/programs/fraction/src/instructions/initialize_fraction.rs
@@ -7,8 +7,23 @@ pub struct InitializeFraction<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
 
-    #[account(init, payer = authority, space = 1 + FractionConfig::INIT_SPACE, seeds = [b"fraction_config", authority.key().as_ref(), name.as_ref()], bump)]
-    pub fraction_config: Box<Account<'info, FractionConfig>>,
+    // Config PDA (program-owned) - stores your FractionConfig data
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + FractionConfig::INIT_SPACE,
+        seeds = [b"fraction_config", authority.key().as_ref(), name.as_ref()],
+        bump
+    )]
+    pub fraction_config: Account<'info, FractionConfig>,
+
+    // Vault PDA (system-owned) - holds SOL and can have ATAs
+    #[account(
+        mut,
+        seeds = [b"fraction_vault", authority.key().as_ref(), name.as_ref()],
+        bump
+    )]
+    pub fraction_vault: SystemAccount<'info>,
 
     pub system_program: Program<'info, System>,
 }
@@ -61,7 +76,8 @@ impl<'info> InitializeFraction<'info> {
             participants,
             bot_wallet,
             incentive_bps: 5u8,
-            bump: bumps.fraction_config,
+            vault_bump: bumps.fraction_vault,      // 🔑 Store vault bump
+            config_bump: bumps.fraction_config,    // Store config bump
         });
 
         Ok(())

--- a/programs/fraction/src/instructions/initialize_fraction.rs
+++ b/programs/fraction/src/instructions/initialize_fraction.rs
@@ -56,7 +56,9 @@ impl<'info> InitializeFraction<'info> {
         ];
         for i in 0..5 {
             for j in (i + 1)..5 {
-                if wallets[i] == anchor_lang::system_program::ID || wallets[j] == anchor_lang::system_program::ID {
+                if wallets[i] == anchor_lang::system_program::ID
+                    || wallets[j] == anchor_lang::system_program::ID
+                {
                     continue;
                 }
                 require!(

--- a/programs/fraction/src/instructions/update_fraction.rs
+++ b/programs/fraction/src/instructions/update_fraction.rs
@@ -8,7 +8,7 @@ pub struct UpdateFraction<'info> {
     #[account(
         mut,
         seeds = [b"fraction_config", fraction_config.authority.key().as_ref(), fraction_config.name.as_ref()],
-        bump = fraction_config.bump,   
+        bump = fraction_config.config_bump,   
         has_one = authority,
     )]
     pub fraction_config: Box<Account<'info, FractionConfig>>,

--- a/programs/fraction/src/lib.rs
+++ b/programs/fraction/src/lib.rs
@@ -9,7 +9,7 @@ pub use states::*;
 pub mod errors;
 pub use errors::*;
 
-declare_id!("FracVQuBhSeBvbw1qNrJKkDmcdPcFYWdneoKbJa3HMrj");
+declare_id!("Ck2PtB73t36kjk4mLUztwsBV9jvq7q3mGfSNmQevwFgg");
 
 #[program]
 pub mod fraction {

--- a/programs/fraction/src/lib.rs
+++ b/programs/fraction/src/lib.rs
@@ -9,28 +9,22 @@ pub use states::*;
 pub mod errors;
 pub use errors::*;
 
-declare_id!("Ck2PtB73t36kjk4mLUztwsBV9jvq7q3mGfSNmQevwFgg");
+declare_id!("FracVQuBhSeBvbw1qNrJKkDmcdPcFYWdneoKbJa3HMrj");
 
 #[program]
 pub mod fraction {
     use super::*;
 
-    #[instruction(discriminator = 1)]
     pub fn initialize_fraction(
         ctx: Context<InitializeFraction>,
         name: String,
         participants: [Participant; 5],
         bot_wallet: Pubkey,
     ) -> Result<()> {
-        ctx.accounts.initialize_fraction(
-            name,
-            participants,
-            bot_wallet,
-            &ctx.bumps,
-        )
+        ctx.accounts
+            .initialize_fraction(name, participants, bot_wallet, &ctx.bumps)
     }
 
-    #[instruction(discriminator = 2)]
     pub fn update_fraction(
         ctx: Context<UpdateFraction>,
         participants: [Participant; 5],
@@ -39,12 +33,10 @@ pub mod fraction {
         ctx.accounts.update_fraction(participants, bot_wallet)
     }
 
-    #[instruction(discriminator = 3)]
     pub fn claim_and_distribute(ctx: Context<ClaimAndDistribute>) -> Result<()> {
         ctx.accounts.claim_and_distribute()
     }
 }
-
 
 #[cfg(not(feature = "no-entrypoint"))]
 use solana_security_txt::security_txt;

--- a/programs/fraction/src/states/fraction_config.rs
+++ b/programs/fraction/src/states/fraction_config.rs
@@ -2,7 +2,7 @@ use crate::states::participant::Participant;
 use anchor_lang::prelude::*;
 
 #[derive(InitSpace)]
-#[account(discriminator = 1)]
+#[account]
 pub struct FractionConfig {
     pub authority: Pubkey,
     #[max_len(32)]
@@ -10,6 +10,6 @@ pub struct FractionConfig {
     pub participants: [Participant; 5],
     pub bot_wallet: Pubkey,
     pub incentive_bps: u8,
-    pub vault_bump: u8,     
-    pub config_bump: u8,    
+    pub vault_bump: u8,
+    pub config_bump: u8,
 }

--- a/programs/fraction/src/states/fraction_config.rs
+++ b/programs/fraction/src/states/fraction_config.rs
@@ -10,5 +10,6 @@ pub struct FractionConfig {
     pub participants: [Participant; 5],
     pub bot_wallet: Pubkey,
     pub incentive_bps: u8,
-    pub bump: u8,
+    pub vault_bump: u8,     
+    pub config_bump: u8,    
 }

--- a/sdk/instructions/claim.ts
+++ b/sdk/instructions/claim.ts
@@ -41,10 +41,20 @@ async function claimAndDistributeIx(program: Program<Fraction>, config: PublicKe
         true
     )
 
+    const [fractionVaultPda] = PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("fraction_vault"),
+          fraction.authority.toBuffer(),
+          Buffer.from(fraction.name),
+        ],
+        program.programId
+      );
+
     const ix = await program.methods.claimAndDistribute().accountsStrict({
         authority: fraction.authority,
         botWallet: fraction.botWallet,
         fractionConfig: config,
+        fractionVault: fractionVaultPda,
         treasury: treasuryAssociatedTokenAccount,
         treasuryMint: mint,
         botTokenAccount: botAssociatedTokenAccount,

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendaifun/fraction",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "TypeScript SDK for Fraction Solana program",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/shared/idl.json
+++ b/sdk/shared/idl.json
@@ -10,7 +10,14 @@
     {
       "name": "claim_and_distribute",
       "discriminator": [
-        3
+        111,
+        147,
+        210,
+        144,
+        253,
+        16,
+        187,
+        238
       ],
       "accounts": [
         {
@@ -60,13 +67,50 @@
           }
         },
         {
+          "name": "fraction_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  114,
+                  97,
+                  99,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "fraction_config.authority",
+                "account": "FractionConfig"
+              },
+              {
+                "kind": "account",
+                "path": "fraction_config.name",
+                "account": "FractionConfig"
+              }
+            ]
+          }
+        },
+        {
           "name": "treasury",
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "account",
-                "path": "fraction_config"
+                "path": "fraction_vault"
               },
               {
                 "kind": "account",
@@ -156,7 +200,14 @@
     {
       "name": "initialize_fraction",
       "discriminator": [
-        1
+        159,
+        21,
+        140,
+        42,
+        52,
+        59,
+        103,
+        82
       ],
       "accounts": [
         {
@@ -187,6 +238,41 @@
                   102,
                   105,
                   103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "arg",
+                "path": "name"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fraction_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  114,
+                  97,
+                  99,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
               },
               {
@@ -232,7 +318,14 @@
     {
       "name": "update_fraction",
       "discriminator": [
-        2
+        176,
+        173,
+        246,
+        104,
+        94,
+        102,
+        30,
+        180
       ],
       "accounts": [
         {
@@ -306,7 +399,14 @@
     {
       "name": "FractionConfig",
       "discriminator": [
-        1
+        164,
+        123,
+        52,
+        71,
+        72,
+        174,
+        132,
+        174
       ]
     }
   ],
@@ -398,7 +498,11 @@
             "type": "u8"
           },
           {
-            "name": "bump",
+            "name": "vault_bump",
+            "type": "u8"
+          },
+          {
+            "name": "config_bump",
             "type": "u8"
           }
         ]

--- a/sdk/shared/idl.ts
+++ b/sdk/shared/idl.ts
@@ -16,7 +16,14 @@ export type Fraction = {
     {
       "name": "claimAndDistribute",
       "discriminator": [
-        3
+        111,
+        147,
+        210,
+        144,
+        253,
+        16,
+        187,
+        238
       ],
       "accounts": [
         {
@@ -66,13 +73,50 @@ export type Fraction = {
           }
         },
         {
+          "name": "fractionVault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  114,
+                  97,
+                  99,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "fraction_config.authority",
+                "account": "fractionConfig"
+              },
+              {
+                "kind": "account",
+                "path": "fraction_config.name",
+                "account": "fractionConfig"
+              }
+            ]
+          }
+        },
+        {
           "name": "treasury",
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "account",
-                "path": "fractionConfig"
+                "path": "fractionVault"
               },
               {
                 "kind": "account",
@@ -162,7 +206,14 @@ export type Fraction = {
     {
       "name": "initializeFraction",
       "discriminator": [
-        1
+        159,
+        21,
+        140,
+        42,
+        52,
+        59,
+        103,
+        82
       ],
       "accounts": [
         {
@@ -193,6 +244,41 @@ export type Fraction = {
                   102,
                   105,
                   103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "arg",
+                "path": "name"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fractionVault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  114,
+                  97,
+                  99,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
               },
               {
@@ -238,7 +324,14 @@ export type Fraction = {
     {
       "name": "updateFraction",
       "discriminator": [
-        2
+        176,
+        173,
+        246,
+        104,
+        94,
+        102,
+        30,
+        180
       ],
       "accounts": [
         {
@@ -312,7 +405,14 @@ export type Fraction = {
     {
       "name": "fractionConfig",
       "discriminator": [
-        1
+        164,
+        123,
+        52,
+        71,
+        72,
+        174,
+        132,
+        174
       ]
     }
   ],
@@ -404,7 +504,11 @@ export type Fraction = {
             "type": "u8"
           },
           {
-            "name": "bump",
+            "name": "vaultBump",
+            "type": "u8"
+          },
+          {
+            "name": "configBump",
             "type": "u8"
           }
         ]

--- a/sdk/test/index.test.ts
+++ b/sdk/test/index.test.ts
@@ -3,7 +3,8 @@ import { Keypair, PublicKey, Connection, VersionedTransaction, LAMPORTS_PER_SOL,
 import { Fraction, createFractionIx } from "../index"
 import { createMint, getOrCreateAssociatedTokenAccount, mintTo } from "@solana/spl-token"
 
-const rpc = "http://127.0.0.1:8899"
+// const rpc = "http://127.0.0.1:8899"
+const rpc = "https://api.devnet.solana.com"
 
 describe("Fraction", () => {
 

--- a/sdk/types/index.ts
+++ b/sdk/types/index.ts
@@ -27,5 +27,6 @@ export type FractionConfig = {
     participants: Participant[];
     botWallet: PublicKey;
     incentiveBps: number;
-    bump: number;
+    vaultBump: number;
+    configBump: number;
 }


### PR DESCRIPTION
There's was an edge case in current design where wallets were unable to send funds to the fraction config. 

This was due to fraction config's PDA, being owned by the fraction program. 

Now the PDA, is owned by the SystemProgram. 