### PR TITLE
refactor: use MAX_PARTICIPANTS constant for dynamic array generation

### DIFF
--- a/programs/fraction/src/instructions/initialize_fraction.rs
+++ b/programs/fraction/src/instructions/initialize_fraction.rs
@@ -1,6 +1,8 @@
 use crate::{errors::*, states::*};
 use anchor_lang::prelude::*;
 
+pub const MAX_PARTICIPANTS: usize = 5;
+
 #[derive(Accounts)]
 #[instruction(name: String)]
 pub struct InitializeFraction<'info> {
@@ -32,7 +34,7 @@ impl<'info> InitializeFraction<'info> {
     pub fn initialize_fraction(
         &mut self,
         name: String,
-        participants: [Participant; 5],
+        participants: [Participant; MAX_PARTICIPANTS],
         bot_wallet: Pubkey,
         bumps: &InitializeFractionBumps,
     ) -> Result<()> {
@@ -54,8 +56,8 @@ impl<'info> InitializeFraction<'info> {
             participants[3].wallet,
             participants[4].wallet,
         ];
-        for i in 0..5 {
-            for j in (i + 1)..5 {
+        for i in 0..MAX_PARTICIPANTS {
+            for j in (i + 1)..MAX_PARTICIPANTS {
                 if wallets[i] == anchor_lang::system_program::ID || wallets[j] == anchor_lang::system_program::ID {
                     continue;
                 }

--- a/programs/fraction/src/instructions/update_fraction.rs
+++ b/programs/fraction/src/instructions/update_fraction.rs
@@ -1,5 +1,8 @@
+use std::char::MAX;
+
 use crate::{errors::*, states::*};
 use anchor_lang::prelude::*;
+use crate::instructions::MAX_PARTICIPANTS;
 
 #[derive(Accounts)]
 pub struct UpdateFraction<'info> {
@@ -17,7 +20,7 @@ pub struct UpdateFraction<'info> {
 impl<'info> UpdateFraction<'info> {
     pub fn update_fraction(
         &mut self,
-        participants: [Participant; 5],
+        participants: [Participant; MAX_PARTICIPANTS],
         bot_wallet: Pubkey,
     ) -> Result<()> {
         let total_shares: u32 = participants.iter().map(|p| p.share_bps as u32).sum();
@@ -33,15 +36,9 @@ impl<'info> UpdateFraction<'info> {
         }
 
         // Check for duplicate participant wallets
-        let wallets = [
-            participants[0].wallet,
-            participants[1].wallet,
-            participants[2].wallet,
-            participants[3].wallet,
-            participants[4].wallet,
-        ];
-        for i in 0..5 {
-            for j in (i + 1)..5 {
+        let wallets: [Pubkey; MAX_PARTICIPANTS] = std::array::from_fn(|i| participants[i].wallet);
+        for i in 0..MAX_PARTICIPANTS {
+            for j in (i + 1)..MAX_PARTICIPANTS {
                 if wallets[i] == anchor_lang::system_program::ID || wallets[j] == anchor_lang::system_program::ID {
                     continue;
                 }

--- a/programs/fraction/src/lib.rs
+++ b/programs/fraction/src/lib.rs
@@ -18,7 +18,7 @@ pub mod fraction {
     pub fn initialize_fraction(
         ctx: Context<InitializeFraction>,
         name: String,
-        participants: [Participant; 5],
+        participants: [Participant; MAX_PARTICIPANTS],
         bot_wallet: Pubkey,
     ) -> Result<()> {
         ctx.accounts
@@ -27,7 +27,7 @@ pub mod fraction {
 
     pub fn update_fraction(
         ctx: Context<UpdateFraction>,
-        participants: [Participant; 5],
+        participants: [Participant; MAX_PARTICIPANTS],
         bot_wallet: Pubkey,
     ) -> Result<()> {
         ctx.accounts.update_fraction(participants, bot_wallet)


### PR DESCRIPTION
- Added `MAX_PARTICIPANTS` constant to replace hardcoded number 5 (even though we require compile time declarations we have used hard coded values at 5 different places for the same use-case)

- Updated wallet array generation to use the constant instead of manual indexing

### Why this was needed
- Maintainability: No more scattered magic numbers throughout the code
- Single source of truth: Participant limit is now defined in one place